### PR TITLE
docs: correct Value field size limit in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ scalable file sharing capabilities.
 - **Packet Identifier (8 bits):** Uniquely identifies each packet.
 - **Tag (T, 8 bits):** Specifies the type of data in the value field.
 - **Length (L, 32 bits):** Indicates the length (in bytes) of the Value field, supporting up to 4GiB of data.
-- **Value (V, variable length):** The actual data, up to 1GiB.
+- **Value (V, variable length):** The actual data, up to 4GiB.
 
 ## Tag Definitions
 


### PR DESCRIPTION
This pull request updates the documentation to reflect an increase in the maximum supported size for the `Value` field in the scalable file sharing protocol.

* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L12-R12): Updated the description of the `Value` field to indicate support for up to 4GiB of data instead of 1GiB.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
