### PR TITLE
feat: Add "DownloadPersistentCachePiece" tag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ scalable file sharing capabilities.
 | ----- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 0     | Download Piece | Download the content of a piece from a peer. It is composed of `{Task ID}-{Piece ID}`, where the Task ID is a 32-byte SHA-256 value and the Piece ID is a number. |
 | 1     | Piece Content  | The content of a piece, with a maximum size of 1 GiB per piece.                                                                                                   |
+| 0     | Download Persistent Cache Piece | Download the content of a persistent cache piece from a peer. It is composed of `{Task ID}-{Piece ID}`, where the Task ID is a 32-byte SHA-256 value and the Persistent Cache Piece ID is a number. |
 | 2-253 | Reserved       | Reserved for future use.                                                                                                                                          |
 | 254   | Close          | Close connection.                                                                                                                                                 |
 | 255   | Error          | Error message.                                                                                                                                                    |
@@ -40,6 +41,7 @@ scalable file sharing capabilities.
 
 - **Download Piece (Tag=0x00):** Download the content of a piece from a peer.
 - **Piece Content (Tag=0x01):** Raw piece data or piece fragments.
+- **Download Persistent Cache Piece (Tag=0x02):** Download the content of a persistent cache piece from a peer.
 - **Error (Tag=0xFF):** Conveys error.
 - **Close (Tag=0xFE):** Indicates the end of a connection.
 - **Reserved Tags:** Tags 2-253 may be allocated for metadata, compression, encryption, or future protocol extensions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod tlv;
 
 /// HEADER_SIZE is the size of the Vortex packet header including the packet identifier, tag, and
 /// length.
-const HEADER_SIZE: usize = 6;
+pub const HEADER_SIZE: usize = 6;
 
 /// MAX_VALUE_SIZE is the maximum size of the value field (4 GiB).
 const MAX_VALUE_SIZE: usize = 4 * 1024 * 1024 * 1024;
@@ -62,6 +62,7 @@ pub struct Header {
 pub enum Vortex {
     DownloadPiece(Header, tlv::download_piece::DownloadPiece),
     PieceContent(Header, tlv::piece_content::PieceContent),
+    DownloadPersistentCachePiece(Header, tlv::download_piece::DownloadPiece),
     Reserved(Header),
     Close(Header),
     Error(Header, tlv::error::Error),
@@ -87,6 +88,7 @@ impl Vortex {
         match self {
             Vortex::DownloadPiece(header, _) => header.packet_id,
             Vortex::PieceContent(header, _) => header.packet_id,
+            Vortex::DownloadPersistentCachePiece(header, _) => header.packet_id,
             Vortex::Reserved(header) => header.packet_id,
             Vortex::Close(header) => header.packet_id,
             Vortex::Error(header, _) => header.packet_id,
@@ -99,6 +101,7 @@ impl Vortex {
         match self {
             Vortex::DownloadPiece(header, _) => &header.tag,
             Vortex::PieceContent(header, _) => &header.tag,
+            Vortex::DownloadPersistentCachePiece(header, _) => &header.tag,
             Vortex::Reserved(header) => &header.tag,
             Vortex::Close(header) => &header.tag,
             Vortex::Error(header, _) => &header.tag,
@@ -111,6 +114,7 @@ impl Vortex {
         match self {
             Vortex::DownloadPiece(header, _) => header.length,
             Vortex::PieceContent(header, _) => header.length,
+            Vortex::DownloadPersistentCachePiece(header, _) => header.length,
             Vortex::Reserved(header) => header.length,
             Vortex::Close(header) => header.length,
             Vortex::Error(header, _) => header.length,
@@ -165,6 +169,9 @@ impl Vortex {
             Vortex::PieceContent(header, piece_content) => {
                 (header, Into::<Bytes>::into(piece_content.clone()))
             }
+            Vortex::DownloadPersistentCachePiece(header, download_piece) => {
+                (header, Into::<Bytes>::into(download_piece.clone()))
+            }
             Vortex::Reserved(header) => (header, Bytes::new()),
             Vortex::Close(header) => (header, Bytes::new()),
             Vortex::Error(header, err) => (header, Into::<Bytes>::into(err.clone())),
@@ -193,6 +200,10 @@ impl TryFrom<(tlv::Tag, Header, Bytes)> for Vortex {
             tlv::Tag::PieceContent => {
                 let piece_content = tlv::piece_content::PieceContent::try_from(value)?;
                 Ok(Vortex::PieceContent(header, piece_content))
+            }
+            tlv::Tag::DownloadPersistentCachePiece => {
+                let download_piece = tlv::download_piece::DownloadPiece::try_from(value)?;
+                Ok(Vortex::DownloadPersistentCachePiece(header, download_piece))
             }
             tlv::Tag::Reserved(_) => Ok(Vortex::Reserved(header)),
             tlv::Tag::Close => Ok(Vortex::Close(header)),
@@ -228,6 +239,17 @@ mod tests {
             .expect("Failed to create packet");
 
         assert_eq!(packet.tag(), &Tag::PieceContent);
+        assert_eq!(packet.length(), value.len());
+    }
+
+    #[test]
+    fn test_new_download_persistent_cache_piece() {
+        let tag = Tag::DownloadPersistentCachePiece;
+        let value = Bytes::from("a".repeat(32) + "-42");
+        let packet = Vortex::new(tag, value.clone()).expect("Failed to create Vortex packet");
+
+        assert_eq!(packet.packet_id(), packet.packet_id());
+        assert_eq!(packet.tag(), &tag);
         assert_eq!(packet.length(), value.len());
     }
 

--- a/src/tlv/mod.rs
+++ b/src/tlv/mod.rs
@@ -30,7 +30,11 @@ pub enum Tag {
     /// The content of a piece, with a maximum size of 4 GiB per piece.
     PieceContent = 1,
 
-    /// Reserved for future use, for tags 2-254.
+    /// Download the content of a persistent_cache_piece from a peer. It is composed of `{Task ID}-{Piece ID}`,
+    /// where the Task ID is a 32-byte SHA-256 value and the Piece ID is a number.
+    DownloadPersistentCachePiece = 2,
+
+    /// Reserved for future use, for tags 3-254.
     Reserved(u8),
 
     /// Close the connection. If server or client receives this tag, it will close the connection.
@@ -49,7 +53,8 @@ impl TryFrom<u8> for Tag {
         match value {
             0 => Ok(Tag::DownloadPiece),
             1 => Ok(Tag::PieceContent),
-            2..=253 => Ok(Tag::Reserved(value)),
+            2 => Ok(Tag::DownloadPersistentCachePiece),
+            3..=253 => Ok(Tag::Reserved(value)),
             254 => Ok(Tag::Close),
             255 => Ok(Tag::Error),
         }
@@ -63,6 +68,7 @@ impl From<Tag> for u8 {
         match tag {
             Tag::DownloadPiece => 0,
             Tag::PieceContent => 1,
+            Tag::DownloadPersistentCachePiece => 2,
             Tag::Reserved(value) => value,
             Tag::Close => 254,
             Tag::Error => 255,
@@ -78,7 +84,8 @@ mod tests {
     fn test_try_from_u8() {
         assert_eq!(Tag::try_from(0), Ok(Tag::DownloadPiece));
         assert_eq!(Tag::try_from(1), Ok(Tag::PieceContent));
-        assert_eq!(Tag::try_from(2), Ok(Tag::Reserved(2)));
+        assert_eq!(Tag::try_from(2), Ok(Tag::DownloadPersistentCachePiece));
+        assert_eq!(Tag::try_from(3), Ok(Tag::Reserved(3)));
         assert_eq!(Tag::try_from(253), Ok(Tag::Reserved(253)));
         assert_eq!(Tag::try_from(254), Ok(Tag::Close));
         assert_eq!(Tag::try_from(255), Ok(Tag::Error));
@@ -88,7 +95,8 @@ mod tests {
     fn test_from_tag() {
         assert_eq!(u8::from(Tag::DownloadPiece), 0);
         assert_eq!(u8::from(Tag::PieceContent), 1);
-        assert_eq!(u8::from(Tag::Reserved(2)), 2);
+        assert_eq!(u8::from(Tag::DownloadPersistentCachePiece), 2);
+        assert_eq!(u8::from(Tag::Reserved(3)), 3);
         assert_eq!(u8::from(Tag::Reserved(253)), 253);
         assert_eq!(u8::from(Tag::Close), 254);
         assert_eq!(u8::from(Tag::Error), 255);

--- a/tests/prop_tests.rs
+++ b/tests/prop_tests.rs
@@ -17,6 +17,12 @@ fn generate_value_bytes(tag: Tag) -> Bytes {
             // PieceContent can be any bytes.
             vec![1, 2, 3, 4].into()
         }
+        Tag::DownloadPersistentCachePiece => {
+            // Task ID must be 32 bytes (64 hex chars).
+            let task_id = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+            let piece_id = 42;
+            format!("{}-{}", task_id, piece_id).into_bytes().into()
+        }
         Tag::Close => {
             // Close tag can be empty.
             vec![].into()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This change introduces a Tag field `DownloadPersistentCachePiece` to distinguish between download pieces and persistent cache pieces, allowing for separate processing logic.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/design/pull/8
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
