### PR TITLE
refactor: vortex protocol 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,10 +90,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -131,6 +170,12 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -265,6 +310,30 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "is-terminal"
@@ -636,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,9 +782,11 @@ name = "vortex-protocol"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "chrono",
  "criterion",
  "proptest",
  "rand 0.8.5",
+ "serde",
  "thiserror",
 ]
 
@@ -822,6 +899,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2021"
 thiserror = "2.0"
 rand = "0.8"
 bytes = "1"
+serde = { version = "1.0", features = ["derive"] }
+chrono = { version = "0.4.41", features = ["serde", "clock"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -32,10 +32,3 @@ cargo bench
 # Run specific benchmark group
 cargo bench "Vortex Packet Creation"
 ```
-
-The benchmarks cover various packet sizes:
-
-- Small packets (32 bytes)
-- Medium packets (1 KB)
-- Large packets (1 MB)
-- Extra large packets (16 MB)

--- a/benches/vortex.rs
+++ b/benches/vortex.rs
@@ -15,49 +15,28 @@
  */
 
 use bytes::Bytes;
+use chrono::Utc;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::time::Duration;
+use vortex_protocol::tlv::download_piece::DownloadPiece;
+use vortex_protocol::tlv::piece_content::PieceContent;
 use vortex_protocol::tlv::Tag;
 use vortex_protocol::Vortex;
 
 fn vortex_packet_creation(c: &mut Criterion) {
     let mut group = c.benchmark_group("Vortex Packet Creation");
 
-    group.bench_function("Create Small Packet (32 bytes)", |b| {
+    group.bench_function("Create DownloadPiece Vortex", |b| {
         b.iter(|| {
-            let tag = black_box(Tag::PieceContent);
-            let value = black_box(Bytes::from("a".repeat(32)));
-            let _ = Vortex::new(tag, value);
-        });
-    });
+            let tag = black_box(Tag::DownloadPiece);
+            let value = black_box(
+                DownloadPiece::new(
+                    "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".to_string(),
+                    42,
+                )
+                .into(),
+            );
 
-    group.bench_function("Create Medium Packet (1 KB)", |b| {
-        b.iter(|| {
-            let tag = black_box(Tag::PieceContent);
-            let value = black_box(Bytes::from("a".repeat(1024)));
-            let _ = Vortex::new(tag, value);
-        });
-    });
-
-    group.bench_function("Create Large Packet (1 MB)", |b| {
-        b.iter(|| {
-            let tag = black_box(Tag::PieceContent);
-            let value = black_box(Bytes::from("a".repeat(1024 * 1024)));
-            let _ = Vortex::new(tag, value);
-        });
-    });
-
-    group.bench_function("Create XLarge Packet (16 MB)", |b| {
-        b.iter(|| {
-            let tag = black_box(Tag::PieceContent);
-            let value = black_box(Bytes::from("a".repeat(16 * 1024 * 1024)));
-            let _ = Vortex::new(tag, value);
-        });
-    });
-
-    group.bench_function("Create XXLarge Packet (128 MB)", |b| {
-        b.iter(|| {
-            let tag = black_box(Tag::PieceContent);
-            let value = black_box(Bytes::from("a".repeat(128 * 1024 * 1024)));
             let _ = Vortex::new(tag, value);
         });
     });
@@ -68,48 +47,31 @@ fn vortex_packet_creation(c: &mut Criterion) {
 fn vortex_packet_serialization(c: &mut Criterion) {
     let mut group = c.benchmark_group("Vortex Packet Serialization");
 
-    group.bench_function("Serialize Small Packet (32 bytes)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(32));
-        let packet = Vortex::new(tag, value).unwrap();
+    group.bench_function("Serialize PieceContent Packet", |b| {
         b.iter(|| {
-            black_box(Bytes::from(packet.clone()));
+            let piece_content = black_box(PieceContent::new(
+                1,
+                1,
+                10,
+                "crc32:864bbb04".to_string(),
+                "127.0.0.1-foo".to_string(),
+                1,
+                Duration::from_secs(30),
+                Utc::now().naive_utc(),
+            ));
+
+            let _bytes: Bytes = piece_content.into();
         });
     });
 
-    group.bench_function("Serialize Medium Packet (1 KB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(1024));
-        let packet = Vortex::new(tag, value).unwrap();
+    group.bench_function("Serialize DownloadPiece Packet", |b| {
         b.iter(|| {
-            black_box(Bytes::from(packet.clone()));
-        });
-    });
+            let download_piece = black_box(DownloadPiece::new(
+                "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".to_string(),
+                42,
+            ));
 
-    group.bench_function("Serialize Large Packet (1 MB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(1024 * 1024));
-        let packet = Vortex::new(tag, value).unwrap();
-        b.iter(|| {
-            black_box(Bytes::from(packet.clone()));
-        });
-    });
-
-    group.bench_function("Serialize XLarge Packet (16 MB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(16 * 1024 * 1024));
-        let packet = Vortex::new(tag, value).unwrap();
-        b.iter(|| {
-            black_box(Bytes::from(packet.clone()));
-        });
-    });
-
-    group.bench_function("Serialize XXLarge Packet (128 MB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(128 * 1024 * 1024));
-        let packet = Vortex::new(tag, value).unwrap();
-        b.iter(|| {
-            black_box(Bytes::from(packet.clone()));
+            let _bytes: Bytes = download_piece.into();
         });
     });
 
@@ -119,53 +81,37 @@ fn vortex_packet_serialization(c: &mut Criterion) {
 fn vortex_packet_deserialization(c: &mut Criterion) {
     let mut group = c.benchmark_group("Vortex Packet Deserialization");
 
-    group.bench_function("Deserialize Small Packet (32 bytes)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(32));
-        let packet = Vortex::new(tag, value).unwrap();
-        let bytes: Bytes = packet.into();
+    group.bench_function("Deserialize PieceContent Packet", |b| {
         b.iter(|| {
-            black_box(Vortex::try_from(bytes.clone()).unwrap());
+            let bytes: Bytes = black_box(
+                PieceContent::new(
+                    1,
+                    1,
+                    10,
+                    "crc32:864bbb04".to_string(),
+                    "127.0.0.1-foo".to_string(),
+                    1,
+                    Duration::from_secs(30),
+                    Utc::now().naive_utc(),
+                )
+                .into(),
+            );
+
+            let _piece_content: PieceContent = bytes.try_into().unwrap();
         });
     });
 
-    group.bench_function("Deserialize Medium Packet (1 KB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(1024));
-        let packet = Vortex::new(tag, value).unwrap();
-        let bytes: Bytes = packet.into();
+    group.bench_function("Deserialize DownloadPiece Packet", |b| {
         b.iter(|| {
-            black_box(Vortex::try_from(bytes.clone()).unwrap());
-        });
-    });
+            let bytes: Bytes = black_box(
+                DownloadPiece::new(
+                    "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".to_string(),
+                    42,
+                )
+                .into(),
+            );
 
-    group.bench_function("Deserialize Large Packet (1 MB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(1024 * 1024));
-        let packet = Vortex::new(tag, value).unwrap();
-        let bytes: Bytes = packet.into();
-        b.iter(|| {
-            black_box(Vortex::try_from(bytes.clone()).unwrap());
-        });
-    });
-
-    group.bench_function("Deserialize XLarge Packet (16 MB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(16 * 1024 * 1024));
-        let packet = Vortex::new(tag, value).unwrap();
-        let bytes: Bytes = packet.into();
-        b.iter(|| {
-            black_box(Vortex::try_from(bytes.clone()).unwrap());
-        });
-    });
-
-    group.bench_function("Deserialize XXLarge Packet (128 MB)", |b| {
-        let tag = Tag::PieceContent;
-        let value = Bytes::from("a".repeat(128 * 1024 * 1024));
-        let packet = Vortex::new(tag, value).unwrap();
-        let bytes: Bytes = packet.into();
-        b.iter(|| {
-            black_box(Vortex::try_from(bytes.clone()).unwrap());
+            let _download_piece: DownloadPiece = bytes.try_into().unwrap();
         });
     });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,9 @@ scalable file sharing capabilities.
 
 ## Protocol Fields
 
-- **Packet Identifier (8 bits):** Uniquely identifies each packet.
-- **Tag (T, 8 bits):** Specifies the type of data in the value field.
-- **Length (L, 32 bits):** Indicates the length (in bytes) of the Value field, supporting up to 4GiB of data.
+- **Packet Identifier (1 bytes):** Uniquely identifies each packet.
+- **Tag (T, 1 bytes):** Specifies the type of data in the value field.
+- **Length (L, 4 bytes):** Indicates the length (in bytes) of the Value field, supporting up to 4GiB of data.
 - **Value (V, variable length):** The actual data, up to 4GiB.
 
 ## Tag Definitions
@@ -27,13 +27,13 @@ scalable file sharing capabilities.
 
 ## Packet Format
 
-| Packet ID (8 bits) | Tag (8 bits) | Length (32 bits) | Value (up to 4GiB) |
-| ------------------ | ------------ | ---------------- | ------------------ |
-| 8-bit              | 8-bit        | 32-bit           | variable           |
+| Packet ID (1 bytes) | Tag (1 bytes) | Length (4 bytes) | Value (up to 4GiB) |
+| ------------------- | ------------- | ---------------- | ------------------ |
+| 1-bytes             | 1-bytes       | 4-bytes          | variable           |
 
-- **Packet ID:** 8-bit unsigned integer.
-- **Tag:** 8-bit field describing the content type.
-- **Length:** 32-bit field specifying the size of the Value.
+- **Packet ID:** 1-bytes unsigned integer.
+- **Tag:** 1-bytes field describing the content type.
+- **Length:** 4-bytes field specifying the size of the Value.
 - **Value:** Actual data, size determined by Length.
 
 ## Behavior

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -25,6 +25,10 @@ pub enum Error {
     #[error("invalid length, cause: {0}")]
     InvalidLength(String),
 
+    /// InvalidTag indicates an invalid tag.
+    #[error("invalid tag: {0}")]
+    InvalidTag(String),
+
     /// TryFromSliceError indicates a conversion error.
     #[error(transparent)]
     TryFromSliceError(#[from] std::array::TryFromSliceError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 use crate::error::{Error, Result};
 use bytes::{BufMut, Bytes, BytesMut};
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub mod error;
 pub mod tlv;
@@ -29,11 +30,56 @@ pub const HEADER_SIZE: usize = 6;
 const MAX_VALUE_SIZE: usize = 4 * 1024 * 1024 * 1024;
 
 /// Header represents the Vortex packet header.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Header {
     id: u8,
     tag: tlv::Tag,
-    length: usize,
+    length: u32,
+}
+
+/// Header implements the Header functions.
+impl Header {
+    /// new creates a new Vortex packet header.
+    pub fn new(tag: tlv::Tag, value_length: u32) -> Self {
+        let mut rng = thread_rng();
+        Self {
+            id: rng.gen(),
+            tag,
+            length: value_length,
+        }
+    }
+}
+
+/// Implement TryFrom<Bytes> for Header.
+impl TryFrom<Bytes> for Header {
+    type Error = Error;
+
+    /// try_from converts a Bytes into a Header.
+    fn try_from(bytes: Bytes) -> Result<Self> {
+        if bytes.len() != HEADER_SIZE {
+            return Err(Error::InvalidPacket(format!(
+                "expected min {HEADER_SIZE} bytes, got {}",
+                bytes.len()
+            )));
+        }
+
+        let id = bytes[0];
+        let tag = bytes[1].into();
+        let length = u32::from_be_bytes(bytes[2..HEADER_SIZE].try_into()?);
+        Ok(Header { id, tag, length })
+    }
+}
+
+/// Implement From<Header> for Bytes.
+impl From<Header> for Bytes {
+    /// from converts a Header into Bytes.
+    fn from(header: Header) -> Self {
+        let mut bytes = BytesMut::with_capacity(HEADER_SIZE);
+        bytes.put_u8(header.id);
+        bytes.put_u8(header.tag.into());
+        bytes.put_u32(header.length);
+        bytes.freeze()
+    }
 }
 
 /// Vortex Protocol
@@ -42,19 +88,19 @@ pub struct Header {
 /// efficient and flexible data transmission. Designed for reliable and scalable file sharing.
 ///
 /// Packet Format:
-///     - Packet Identifier (8 bits): Uniquely identifies each packet
-///     - Tag (8 bits): Specifies data type in value field
-///     - Length (32 bits): Indicates Value field length, up to 4 GiB
+///     - Packet Identifier (1 bytes): Uniquely identifies each packet
+///     - Tag (1 bytes): Specifies data type in value field
+///     - Length (8 bytes): Indicates Value field length, up to 4 GiB
 ///     - Value (variable): Actual data content, maximum 1 GiB
 ///
 /// Protocol Format:
 ///
 /// ```text
-/// -------------------------------------------------------------------------------------------------
-/// |                            |                   |                    |                         |
-/// | Packet Identifier (8 bits) |    Tag (8 bits)   |  Length (32 bits)  |   Value (up to 4 GiB)   |
-/// |                            |                   |                    |                         |
-/// -------------------------------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------------------------------
+/// |                             |                    |                    |                         |
+/// | Packet Identifier (1 bytes) |    Tag (1 bytes)   |  Length (8 bytes)  |   Value (up to 4 GiB)   |
+/// |                             |                    |                    |                         |
+/// ---------------------------------------------------------------------------------------------------
 /// ```
 ///
 /// For more information, please refer to the [Vortex Protocol](https://github.com/dragonflyoss/vortex/blob/main/docs/README.md).
@@ -71,14 +117,7 @@ pub enum Vortex {
 impl Vortex {
     /// Creates a new Vortex packet.
     pub fn new(tag: tlv::Tag, value: Bytes) -> Result<Self> {
-        let mut rng = thread_rng();
-        let header = Header {
-            id: rng.gen(),
-            tag,
-            length: value.len(),
-        };
-
-        (tag, header, value).try_into()
+        (tag, Header::new(tag, value.len() as u32), value).try_into()
     }
 
     /// id returns the packet identifier of the Vortex packet.
@@ -109,11 +148,11 @@ impl Vortex {
     #[inline]
     pub fn length(&self) -> usize {
         match self {
-            Vortex::DownloadPiece(header, _) => header.length,
-            Vortex::PieceContent(header, _) => header.length,
-            Vortex::Reserved(header) => header.length,
-            Vortex::Close(header) => header.length,
-            Vortex::Error(header, _) => header.length,
+            Vortex::DownloadPiece(header, _) => header.length as usize,
+            Vortex::PieceContent(header, _) => header.length as usize,
+            Vortex::Reserved(header) => header.length as usize,
+            Vortex::Close(header) => header.length as usize,
+            Vortex::Error(header, _) => header.length as usize,
         }
     }
 
@@ -136,32 +175,21 @@ impl TryFrom<Bytes> for Vortex {
 
     /// try_from converts a Bytes into a Vortex packet.
     fn try_from(bytes: Bytes) -> Result<Self> {
-        if bytes.len() < HEADER_SIZE {
-            return Err(Error::InvalidPacket(format!(
-                "expected min {HEADER_SIZE} bytes, got {}",
-                bytes.len()
-            )));
-        }
-
         let mut bytes = BytesMut::from(bytes);
         let header = bytes.split_to(HEADER_SIZE);
         let value = bytes.freeze();
-        let id = header[0];
-        let tag = header[1]
-            .try_into()
-            .map_err(|err| Error::InvalidPacket(format!("invalid tag value: {:?}", err)))?;
-        let length = u32::from_be_bytes(header[2..HEADER_SIZE].try_into()?) as usize;
+        let header: Header = header.freeze().try_into()?;
 
         // Check if the value length matches the specified length.
-        if value.len() != length {
+        if value.len() != header.length as usize {
             return Err(Error::InvalidLength(format!(
                 "value len {} != declared length {}",
                 value.len(),
-                length
+                header.length
             )));
         }
 
-        (tag, Header { id, tag, length }, value).try_into()
+        (header.tag, header, value).try_into()
     }
 }
 
@@ -170,15 +198,11 @@ impl From<Vortex> for Bytes {
     /// from converts a Vortex packet to Bytes.
     fn from(packet: Vortex) -> Self {
         let (header, value) = match packet {
-            Vortex::DownloadPiece(header, download_piece) => {
-                (header, Into::<Bytes>::into(download_piece.clone()))
-            }
-            Vortex::PieceContent(header, piece_content) => {
-                (header, Into::<Bytes>::into(piece_content.clone()))
-            }
+            Vortex::DownloadPiece(header, download_piece) => (header, download_piece.into()),
             Vortex::Reserved(header) => (header, Bytes::new()),
             Vortex::Close(header) => (header, Bytes::new()),
-            Vortex::Error(header, err) => (header, Into::<Bytes>::into(err.clone())),
+            Vortex::Error(header, err) => (header, err.into()),
+            _ => panic!("unsupported packet type for conversion to Bytes"),
         };
 
         let mut bytes = BytesMut::with_capacity(HEADER_SIZE + value.len());
@@ -196,14 +220,18 @@ impl TryFrom<(tlv::Tag, Header, Bytes)> for Vortex {
 
     /// try_from converts a tuple of Tag, Header, and Bytes into a Vortex packet.
     fn try_from((tag, header, value): (tlv::Tag, Header, Bytes)) -> Result<Self> {
+        if value.len() > MAX_VALUE_SIZE {
+            return Err(Error::InvalidLength(format!(
+                "value length {} exceeds maximum allowed size of {} bytes",
+                value.len(),
+                MAX_VALUE_SIZE
+            )));
+        }
+
         match tag {
             tlv::Tag::DownloadPiece => {
                 let download_piece = tlv::download_piece::DownloadPiece::try_from(value)?;
                 Ok(Vortex::DownloadPiece(header, download_piece))
-            }
-            tlv::Tag::PieceContent => {
-                let piece_content = tlv::piece_content::PieceContent::try_from(value)?;
-                Ok(Vortex::PieceContent(header, piece_content))
             }
             tlv::Tag::Reserved(_) => Ok(Vortex::Reserved(header)),
             tlv::Tag::Close => Ok(Vortex::Close(header)),
@@ -211,6 +239,7 @@ impl TryFrom<(tlv::Tag, Header, Bytes)> for Vortex {
                 let err = tlv::error::Error::try_from(value)?;
                 Ok(Vortex::Error(header, err))
             }
+            _ => panic!("unsupported tag for Vortex packet"),
         }
     }
 }
@@ -222,10 +251,63 @@ mod tests {
     use bytes::Bytes;
 
     #[test]
+    fn test_header_new() {
+        let tag = Tag::DownloadPiece;
+        let value_length = 1024;
+        let header = Header::new(tag, value_length);
+
+        assert_eq!(header.tag, tag);
+        assert_eq!(header.length, value_length);
+        assert!(header.id <= 254);
+    }
+
+    #[test]
+    fn test_header_try_from_bytes_success() {
+        let mut bytes = BytesMut::with_capacity(HEADER_SIZE);
+        bytes.put_u8(42);
+        bytes.put_u8(Tag::DownloadPiece.into());
+        bytes.put_u32(1024);
+        let bytes = bytes.freeze();
+        let header = Header::try_from(bytes).unwrap();
+
+        assert_eq!(header.id, 42);
+        assert_eq!(header.tag, Tag::DownloadPiece);
+        assert_eq!(header.length, 1024);
+    }
+
+    #[test]
+    fn test_header_try_from_bytes_invalid_size() {
+        let bytes = Bytes::from(vec![1, 2, 3]);
+        let result = Header::try_from(bytes);
+        assert!(matches!(result, Err(Error::InvalidPacket(_))));
+    }
+
+    #[test]
+    fn test_header_to_bytes() {
+        let tag = Tag::Close;
+        let header = Header {
+            id: 123,
+            tag,
+            length: 2048,
+        };
+        let bytes: Bytes = header.into();
+
+        assert_eq!(bytes.len(), HEADER_SIZE);
+        assert_eq!(bytes[0], 123);
+        assert_eq!(bytes[1], tag.into());
+        assert_eq!(
+            u32::from_be_bytes(bytes[2..HEADER_SIZE].try_into().unwrap()),
+            2048
+        );
+    }
+
+    #[test]
     fn test_new_download_piece() {
         let tag = Tag::DownloadPiece;
-        let value = Bytes::from("a".repeat(32) + "-42");
-        let packet = Vortex::new(tag, value.clone()).expect("Failed to create Vortex packet");
+        let mut value = BytesMut::with_capacity(68);
+        value.extend_from_slice("a".repeat(64).as_bytes());
+        value.put_u32(42);
+        let packet = Vortex::new(tag, value.clone().freeze()).unwrap();
 
         assert_eq!(packet.id(), packet.id());
         assert_eq!(packet.tag(), &tag);
@@ -233,45 +315,10 @@ mod tests {
     }
 
     #[test]
-    fn test_new_piece_content() {
-        let value = b"piece content";
-        let packet = Vortex::new(Tag::PieceContent, Bytes::from_static(value))
-            .expect("Failed to create packet");
-
-        assert_eq!(packet.tag(), &Tag::PieceContent);
-        assert_eq!(packet.length(), value.len());
-    }
-
-    #[test]
-    fn test_vortex_from_bytes() {
-        let value = b"test data";
-        let packet = Vortex::new(Tag::PieceContent, Bytes::from_static(value))
-            .expect("Failed to create packet");
-        let tag = *packet.tag();
-        let length = packet.length();
-
-        let bytes: Bytes = packet.into();
-        let deserialized: Vortex = bytes.try_into().expect("Failed to deserialize packet");
-
-        assert_eq!(tag, deserialized.tag().clone());
-        assert_eq!(length, deserialized.length());
-    }
-
-    #[test]
-    fn test_vortex_to_bytes() {
-        let value = b"test data";
-        let packet = Vortex::new(Tag::PieceContent, Bytes::from_static(value))
-            .expect("Failed to create packet");
-        let bytes: Bytes = packet.into();
-
-        assert_eq!(bytes.len(), HEADER_SIZE + value.len());
-    }
-
-    #[test]
     fn test_close() {
         let tag = Tag::Close;
         let value = Bytes::new();
-        let packet = Vortex::new(tag, value.clone()).expect("Failed to create Vortex packet");
+        let packet = Vortex::new(tag, value.clone()).unwrap();
 
         assert_eq!(packet.tag(), &tag);
         assert_eq!(packet.length(), value.len());
@@ -283,5 +330,89 @@ mod tests {
         let result = Vortex::new(Tag::PieceContent, value.into());
 
         assert!(matches!(result, Err(Error::InvalidLength(_))));
+    }
+
+    #[test]
+    fn test_vortex_try_from_bytes_success() {
+        let tag = Tag::Close;
+        let header = Header::new(tag, 0);
+        let header_bytes: Bytes = header.clone().into();
+        let value = Bytes::new();
+
+        let mut packet_bytes = BytesMut::new();
+        packet_bytes.extend_from_slice(&header_bytes);
+        packet_bytes.extend_from_slice(&value);
+        let packet = Vortex::try_from(packet_bytes.freeze()).unwrap();
+
+        assert_eq!(packet.tag(), &tag);
+        assert_eq!(packet.length(), 0);
+    }
+
+    #[test]
+    fn test_vortex_try_from_bytes_length_mismatch() {
+        let tag = Tag::Close;
+        let header = Header {
+            id: 1,
+            tag,
+            length: 5,
+        };
+        let header_bytes: Bytes = header.into();
+        let value = Bytes::from("test");
+
+        let mut packet_bytes = BytesMut::new();
+        packet_bytes.extend_from_slice(&header_bytes);
+        packet_bytes.extend_from_slice(&value);
+        let result = Vortex::try_from(packet_bytes.freeze());
+
+        assert!(matches!(result, Err(Error::InvalidLength(_))));
+    }
+
+    #[test]
+    fn test_vortex_to_bytes_download_piece() {
+        let tag = Tag::DownloadPiece;
+        let mut value = BytesMut::with_capacity(68);
+        value.extend_from_slice("a".repeat(64).as_bytes());
+        value.put_u32(42);
+        let packet = Vortex::new(tag, value.clone().freeze()).unwrap();
+        let bytes: Bytes = packet.into();
+
+        assert_eq!(bytes.len(), HEADER_SIZE + value.len());
+    }
+
+    #[test]
+    fn test_vortex_to_bytes_reserved() {
+        let tag = Tag::Reserved(50);
+        let packet = Vortex::new(tag, Bytes::new()).unwrap();
+        let bytes: Bytes = packet.into();
+
+        assert_eq!(bytes.len(), HEADER_SIZE);
+    }
+
+    #[test]
+    fn test_vortex_to_bytes_close() {
+        let tag = Tag::Close;
+        let packet = Vortex::new(tag, Bytes::new()).unwrap();
+        let bytes: Bytes = packet.into();
+
+        assert_eq!(bytes.len(), HEADER_SIZE);
+    }
+
+    #[test]
+    fn test_vortex_to_bytes_error() {
+        let tag = Tag::Error;
+        let value = Bytes::from("error details");
+        let packet = Vortex::new(tag, value.clone()).unwrap();
+        let bytes: Bytes = packet.into();
+
+        assert_eq!(bytes.len(), HEADER_SIZE + value.len());
+    }
+
+    #[test]
+    fn test_max_value_size_boundary() {
+        let tag = Tag::Reserved(50);
+        let value = vec![0; MAX_VALUE_SIZE];
+        let result = Vortex::new(tag, value.into());
+
+        assert!(result.is_ok());
     }
 }

--- a/src/tlv/download_piece.rs
+++ b/src/tlv/download_piece.rs
@@ -18,25 +18,22 @@ use crate::error::{Error, Result};
 use bytes::{BufMut, Bytes, BytesMut};
 use std::convert::TryFrom;
 
-/// SEPARATOR is the separator character used in the download piece request, separating the task ID
-/// and piece number. It is a hyphen character '-'.
-const SEPARATOR: u8 = b'-';
+/// TASK_ID_SIZE is the size of the task ID in bytes.
+const TASK_ID_SIZE: usize = 64;
 
-/// DOWNLOAD_PIECE_SIZE is the size of the download piece request, including the task ID, separator,
-/// and piece number.
-const DOWNLOAD_PIECE_SIZE: usize = 32 + 1 + 4;
+/// PIECE_NUMBER_SIZE is the size of the piece number in bytes.
+const PIECE_NUMBER_SIZE: usize = 4;
 
 /// DownloadPiece represents a download piece request.
 ///
 /// Value Format:
-///   - Task ID (32 bytes): SHA-256 hash of the task ID.
-///   - Separator (1 byte): Separator character '-'.
+///   - Task ID (64 bytes): SHA-256 hash of the task ID.
 ///   - Piece Number (4 bytes): Piece number to download.
 ///
 /// ```text
-/// --------------------------------------------------------------------
-/// | Task ID (32 bytes) | Separator (1 byte) | Piece Number (4 bytes) |
-/// --------------------------------------------------------------------
+/// -----------------------------------------------
+/// | Task ID (64 bytes) | Piece Number (4 bytes) |
+/// -----------------------------------------------
 /// ```
 #[derive(Debug, Clone)]
 pub struct DownloadPiece {
@@ -48,7 +45,7 @@ pub struct DownloadPiece {
 impl DownloadPiece {
     /// new creates a new DownloadPiece request.
     pub fn new(task_id: String, piece_number: u32) -> Self {
-        DownloadPiece {
+        Self {
             task_id,
             piece_number,
         }
@@ -66,7 +63,7 @@ impl DownloadPiece {
 
     /// len returns the length of the download piece request.
     pub fn len(&self) -> usize {
-        DOWNLOAD_PIECE_SIZE
+        TASK_ID_SIZE + PIECE_NUMBER_SIZE
     }
 
     /// is_empty returns whether the download piece request is empty.
@@ -81,25 +78,19 @@ impl TryFrom<Bytes> for DownloadPiece {
 
     /// try_from decodes the download piece request from the byte slice.
     fn try_from(bytes: Bytes) -> Result<Self> {
-        let mut parts = bytes.splitn(2, |&b| b == SEPARATOR);
-        let task_id = std::str::from_utf8(
-            parts
-                .next()
-                .ok_or(Error::InvalidPacket("missing task id".to_string()))?,
-        )?
-        .to_string();
-
-        let piece_number: u32 = std::str::from_utf8(
-            parts
-                .next()
-                .ok_or(Error::InvalidPacket("missing piece number".to_string()))?,
-        )?
-        .trim()
-        .parse()?;
+        if bytes.len() != TASK_ID_SIZE + PIECE_NUMBER_SIZE {
+            return Err(Error::InvalidLength(format!(
+                "expected {} bytes for DownloadPiece, got {}",
+                TASK_ID_SIZE + PIECE_NUMBER_SIZE,
+                bytes.len()
+            )));
+        }
 
         Ok(DownloadPiece {
-            task_id,
-            piece_number,
+            task_id: String::from_utf8(bytes[..TASK_ID_SIZE].to_vec())?,
+            piece_number: u32::from_be_bytes(
+                bytes[TASK_ID_SIZE..TASK_ID_SIZE + PIECE_NUMBER_SIZE].try_into()?,
+            ),
         })
     }
 }
@@ -108,10 +99,9 @@ impl TryFrom<Bytes> for DownloadPiece {
 impl From<DownloadPiece> for Bytes {
     /// from converts the download piece request to a byte slice.
     fn from(piece: DownloadPiece) -> Self {
-        let mut bytes = BytesMut::with_capacity(DOWNLOAD_PIECE_SIZE);
+        let mut bytes = BytesMut::with_capacity(piece.len());
         bytes.extend_from_slice(piece.task_id.as_bytes());
-        bytes.put_u8(SEPARATOR);
-        bytes.extend_from_slice(piece.piece_number.to_string().as_bytes());
+        bytes.put_u32(piece.piece_number);
         bytes.freeze()
     }
 }
@@ -123,13 +113,13 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let task_id = "a".repeat(32);
+        let task_id = "a".repeat(64);
         let piece_number = 42;
         let download_piece = DownloadPiece::new(task_id.clone(), piece_number);
 
         assert_eq!(download_piece.task_id(), task_id);
         assert_eq!(download_piece.piece_number(), piece_number);
-        assert_eq!(download_piece.len(), DOWNLOAD_PIECE_SIZE);
+        assert_eq!(download_piece.len(), TASK_ID_SIZE + PIECE_NUMBER_SIZE);
     }
 
     #[test]
@@ -143,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_valid_conversion() {
-        let task_id = "a".repeat(32);
+        let task_id = "a".repeat(64);
         let piece_number = 42;
         let download_piece = DownloadPiece::new(task_id.clone(), piece_number);
 
@@ -156,22 +146,20 @@ mod tests {
 
     #[test]
     fn test_invalid_conversion() {
-        // Test missing separator.
-        let invalid_bytes = Bytes::from("invalid_input_without_separator");
+        let invalid_bytes =
+            Bytes::from("c993dfb0ecfbe1b4e158891bafff709e5d29d3fcd522e09b183aeb5db1db50111111111");
         let result = DownloadPiece::try_from(invalid_bytes);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::InvalidPacket(_)));
+        assert!(matches!(result.unwrap_err(), Error::InvalidLength(_)));
 
-        // Test missing piece number.
-        let invalid_bytes = Bytes::from("task_id-");
+        let invalid_bytes = Bytes::from("task_id");
         let result = DownloadPiece::try_from(invalid_bytes);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::ParseIntError(_)));
+        assert!(matches!(result.unwrap_err(), Error::InvalidLength(_)));
 
-        // Test invalid piece number.
-        let invalid_bytes = Bytes::from("task_id-invalid");
+        let invalid_bytes = Bytes::from("");
         let result = DownloadPiece::try_from(invalid_bytes);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::ParseIntError(_)));
+        assert!(matches!(result.unwrap_err(), Error::InvalidLength(_)));
     }
 }

--- a/src/tlv/download_piece.rs
+++ b/src/tlv/download_piece.rs
@@ -19,10 +19,10 @@ use bytes::{BufMut, Bytes, BytesMut};
 use std::convert::TryFrom;
 
 /// TASK_ID_SIZE is the size of the task ID in bytes.
-const TASK_ID_SIZE: usize = 64;
+pub const TASK_ID_SIZE: usize = 64;
 
 /// PIECE_NUMBER_SIZE is the size of the piece number in bytes.
-const PIECE_NUMBER_SIZE: usize = 4;
+pub const PIECE_NUMBER_SIZE: usize = 4;
 
 /// DownloadPiece represents a download piece request.
 ///
@@ -87,9 +87,21 @@ impl TryFrom<Bytes> for DownloadPiece {
         }
 
         Ok(DownloadPiece {
-            task_id: String::from_utf8(bytes[..TASK_ID_SIZE].to_vec())?,
+            task_id: String::from_utf8(
+                bytes
+                    .get(..TASK_ID_SIZE)
+                    .ok_or(Error::InvalidPacket(
+                        "insufficient bytes for task id".to_string(),
+                    ))?
+                    .to_vec(),
+            )?,
             piece_number: u32::from_be_bytes(
-                bytes[TASK_ID_SIZE..TASK_ID_SIZE + PIECE_NUMBER_SIZE].try_into()?,
+                bytes
+                    .get(TASK_ID_SIZE..TASK_ID_SIZE + PIECE_NUMBER_SIZE)
+                    .ok_or(Error::InvalidPacket(
+                        "insufficient bytes for piece number".to_string(),
+                    ))?
+                    .try_into()?,
             ),
         })
     }

--- a/src/tlv/error.rs
+++ b/src/tlv/error.rs
@@ -142,8 +142,22 @@ impl TryFrom<Bytes> for Error {
         }
 
         Ok(Error {
-            code: Code::try_from(bytes[0])?,
-            message: String::from_utf8(bytes[CODE_SIZE..].to_vec())?,
+            code: Code::try_from(
+                bytes
+                    .first()
+                    .ok_or(VortexError::InvalidPacket(
+                        "insufficient bytes for code".to_string(),
+                    ))?
+                    .to_owned(),
+            )?,
+            message: String::from_utf8(
+                bytes
+                    .get(CODE_SIZE..)
+                    .ok_or(VortexError::InvalidPacket(
+                        "insufficient bytes for message".to_string(),
+                    ))?
+                    .to_vec(),
+            )?,
         })
     }
 }

--- a/src/tlv/error.rs
+++ b/src/tlv/error.rs
@@ -17,9 +17,8 @@
 use crate::error::{Error as VortexError, Result as VortexResult};
 use bytes::{BufMut, Bytes, BytesMut};
 
-/// SEPARATOR is the separator character used in the error request, separating the error code
-/// and error message. It is a hyphen character ':'.
-const SEPARATOR: u8 = b':';
+/// CODE_SIZE is the size of the error code in bytes.
+const CODE_SIZE: usize = 1;
 
 /// Code represents a error code.
 #[repr(u8)]
@@ -43,10 +42,10 @@ pub enum Code {
 
 /// Implement TryFrom<u8> for Code.
 impl TryFrom<u8> for Code {
-    type Error = ();
+    type Error = VortexError;
 
     /// Converts a u8 to a Code enum.
-    fn try_from(value: u8) -> Result<Self, ()> {
+    fn try_from(value: u8) -> VortexResult<Self> {
         match value {
             0 => Ok(Code::Unknown),
             1 => Ok(Code::InvalidArgument),
@@ -74,14 +73,13 @@ impl From<Code> for u8 {
 /// Error represents a error request.
 ///
 /// Value Format:
-///  - Error Code (8 bits): Error code.
-///  - Separator (1 byte): Separator character ':'.
+///  - Error Code (1 bytes): Error code.
 ///  - Error Message (variable): Error message.
 ///
 /// ```text
-/// ----------------------------------------------------------------------
-/// | Error Code (8 bits) | Separator (1 byte) |      Error Message      |
-/// ----------------------------------------------------------------------
+/// -------------------------------------------------
+/// | Error Code (1 bytes) |      Error Message      |
+/// -------------------------------------------------
 /// ```
 #[derive(Debug, Clone)]
 pub struct Error {
@@ -93,7 +91,7 @@ pub struct Error {
 impl Error {
     /// new creates a new Error request.
     pub fn new(code: Code, message: String) -> Self {
-        Error { code, message }
+        Self { code, message }
     }
 
     /// code returns the error code.
@@ -106,10 +104,10 @@ impl Error {
         &self.message
     }
 
-    /// len returns the length of the error request, including the error code, separator, and error
+    /// len returns the length of the error request, including the error code, error
     /// message.
     pub fn len(&self) -> usize {
-        self.message.len() + 2
+        self.message.len() + CODE_SIZE
     }
 
     /// is_empty returns whether the error request is empty.
@@ -124,7 +122,6 @@ impl From<Error> for Bytes {
     fn from(err: Error) -> Self {
         let mut bytes = BytesMut::with_capacity(err.len());
         bytes.put_u8(err.code.into());
-        bytes.put_u8(SEPARATOR);
         bytes.extend_from_slice(err.message.as_bytes());
         bytes.freeze()
     }
@@ -136,35 +133,18 @@ impl TryFrom<Bytes> for Error {
 
     /// try_from decodes the error request from the byte slice.
     fn try_from(bytes: Bytes) -> VortexResult<Self> {
-        let mut parts = bytes.splitn(2, |&b| b == SEPARATOR);
-
-        let code = parts
-            .next()
-            .ok_or(VortexError::InvalidPacket("missing error code".to_string()))?;
-
-        if code.len() != 1 {
-            return Err(VortexError::InvalidPacket("invalid error code".to_string()));
+        if bytes.len() < CODE_SIZE {
+            return Err(VortexError::InvalidLength(format!(
+                "expected at least {} bytes for Error, got {}",
+                CODE_SIZE,
+                bytes.len()
+            )));
         }
 
-        let code: Code = code
-            .first()
-            .copied()
-            .ok_or(VortexError::InvalidPacket("missing error code".to_string()))?
-            .try_into()
-            .unwrap();
-
-        let message = std::str::from_utf8(parts.next().ok_or(VortexError::InvalidPacket(
-            "missing error message".to_string(),
-        ))?)?
-        .to_string();
-
-        if message.is_empty() {
-            return Err(VortexError::InvalidPacket(
-                "empty error message".to_string(),
-            ));
-        }
-
-        Ok(Error { code, message })
+        Ok(Error {
+            code: Code::try_from(bytes[0])?,
+            message: String::from_utf8(bytes[CODE_SIZE..].to_vec())?,
+        })
     }
 }
 
@@ -181,7 +161,7 @@ mod tests {
 
         assert_eq!(error.code(), code);
         assert_eq!(error.message(), message);
-        assert_eq!(error.len(), message.len() + 2);
+        assert_eq!(error.len(), message.len() + CODE_SIZE);
     }
 
     #[test]
@@ -205,16 +185,7 @@ mod tests {
 
     #[test]
     fn test_from_bytes_invalid_input() {
-        // Test missing separator.
-        let invalid_bytes = Bytes::from("invalid_input_without_separator");
-        assert!(Error::try_from(invalid_bytes).is_err());
-
-        // Test missing error message.
-        let invalid_bytes = Bytes::from(format!("{}:", 1));
-        assert!(Error::try_from(invalid_bytes).is_err());
-
-        // Test invalid error code format.
-        let invalid_bytes = Bytes::from(format!("{}:{}", 256, "Invalid code"));
+        let invalid_bytes = Bytes::from("");
         assert!(Error::try_from(invalid_bytes).is_err());
     }
 }

--- a/src/tlv/mod.rs
+++ b/src/tlv/mod.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use serde::{Deserialize, Serialize};
+
 pub mod close;
 pub mod download_piece;
 pub mod error;
@@ -21,7 +23,7 @@ pub mod piece_content;
 
 /// Tag Definitions
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Tag {
     /// Download the content of a piece from a peer. It is composed of `{Task ID}-{Piece ID}`,
     /// where the Task ID is a 32-byte SHA-256 value and the Piece ID is a number.
@@ -41,17 +43,15 @@ pub enum Tag {
 }
 
 /// Implement TryFrom<u8> for Tag.
-impl TryFrom<u8> for Tag {
-    type Error = ();
-
+impl From<u8> for Tag {
     /// Converts a u8 to a Tag enum.
-    fn try_from(value: u8) -> Result<Self, ()> {
+    fn from(value: u8) -> Self {
         match value {
-            0 => Ok(Tag::DownloadPiece),
-            1 => Ok(Tag::PieceContent),
-            2..=253 => Ok(Tag::Reserved(value)),
-            254 => Ok(Tag::Close),
-            255 => Ok(Tag::Error),
+            0 => Tag::DownloadPiece,
+            1 => Tag::PieceContent,
+            2..=253 => Tag::Reserved(value),
+            254 => Tag::Close,
+            255 => Tag::Error,
         }
     }
 }

--- a/src/tlv/mod.rs
+++ b/src/tlv/mod.rs
@@ -76,12 +76,12 @@ mod tests {
 
     #[test]
     fn test_try_from_u8() {
-        assert_eq!(Tag::try_from(0), Ok(Tag::DownloadPiece));
-        assert_eq!(Tag::try_from(1), Ok(Tag::PieceContent));
-        assert_eq!(Tag::try_from(2), Ok(Tag::Reserved(2)));
-        assert_eq!(Tag::try_from(253), Ok(Tag::Reserved(253)));
-        assert_eq!(Tag::try_from(254), Ok(Tag::Close));
-        assert_eq!(Tag::try_from(255), Ok(Tag::Error));
+        assert_eq!(Tag::from(0), Tag::DownloadPiece);
+        assert_eq!(Tag::from(1), Tag::PieceContent);
+        assert_eq!(Tag::from(2), Tag::Reserved(2));
+        assert_eq!(Tag::from(253), Tag::Reserved(253));
+        assert_eq!(Tag::from(254), Tag::Close);
+        assert_eq!(Tag::from(255), Tag::Error);
     }
 
     #[test]

--- a/src/tlv/piece_content.rs
+++ b/src/tlv/piece_content.rs
@@ -21,28 +21,31 @@ use std::convert::TryFrom;
 use std::time::Duration;
 
 /// METADATA_LENGTH_SIZE is the size of the metadata length in bytes.
-pub const METADATA_LENGTH_SIZE: usize = 8;
+pub const METADATA_LENGTH_SIZE: usize = 4;
 
 /// NUMBER_SIZE is the size of the piece number in bytes.
 const NUMBER_SIZE: usize = 4;
 
-/// OFFSET_SIZE is the size of the offest in bytes.
+/// OFFSET_SIZE is the size of the offset in bytes.
 const OFFSET_SIZE: usize = 8;
 
 /// LENGTH_SIZE is the size of the length in bytes.
 const LENGTH_SIZE: usize = 8;
 
-/// DIGEST_SIZE is the size of the digest in bytes.
-const DIGEST_SIZE: usize = 32;
+/// DIGEST_LENGTH_SIZE is the size of the digest length in bytes.
+const DIGEST_LENGTH_SIZE: usize = 4;
+
+/// PARENT_ID_LENGTH_SIZE is the size of the parent ID length in bytes.
+const PARENT_ID_LENGTH_SIZE: usize = 4;
 
 /// TRAFFIC_TYPE_SIZE is the size of the traffic type in bytes.
 const TRAFFIC_TYPE_SIZE: usize = 1;
 
 /// COST_SIZE is the size of the cost in bytes.
-const COST_SIZE: usize = 64;
+const COST_SIZE: usize = 8;
 
 /// CREATED_AT_SIZE is the size of the created at in bytes.
-const CREATED_AT_SIZE: usize = 64;
+const CREATED_AT_SIZE: usize = 8;
 
 /// PieceContent represents a piece metadata and piece content request.
 ///
@@ -51,7 +54,9 @@ const CREATED_AT_SIZE: usize = 64;
 ///   - Number (4 bytes): Piece number to download.
 ///   - Offset (8 bytes): Byte offset in the file.
 ///   - Length (8 bytes): Length of the piece in bytes.
+///   - Digest Length (8 bytes): Length of the digest field (fixed at 32 bytes).
 ///   - Digest (32 bytes): CRC32 hash of the piece content.
+///   - Parent ID Length (8 bytes): Length of the parent task identifier.
 ///   - Parent ID (variable): Parent task identifier.
 ///   - Traffic Type (1 byte): Network traffic classification type.
 ///   - Cost (64 bytes): Download cost in seconds.
@@ -59,15 +64,15 @@ const CREATED_AT_SIZE: usize = 64;
 ///   - Content (variable): Piece content bytes.
 ///
 /// ```text
-/// --------------------------------------------------------------------------------------------------------------------------------------------------------
-/// | Metadata Length (8 bytes) | Number (4 bytes) |  Offset (8 bytes) |  Length (8 bytes) |  Digest (32 bytes) | Traffic Type (1 byte) |  Cost (64 bytes) |
-/// --------------------------------------------------------------------------------------------------------------------------------------------------------
-/// | Created At (64 bytes) | Parent ID (variable) | Content (variable) |
-/// ---------------------------------------------------------------------
+/// -------------------------------------------------------------------------------------------------------------------------------------
+/// | Metadata Length (4 bytes) | Number (4 bytes) |  Offset (8 bytes) |  Length (8 bytes) | Digest Length(8 bytes) | Digest (variable) |
+/// ------------------------------------------------------------------------------------------------------------------------------------------
+/// | Parent ID Length(8 bytes) | Parent ID (variable) | Traffic Type (1 byte) | Cost (8 bytes) | Created At (8 bytes) |  Content (variable) |
+/// ------------------------------------------------------------------------------------------------------------------------------------------
 /// ```
 #[derive(Debug, Clone)]
 pub struct PieceContent {
-    metadata_length: u64,
+    metadata_length: u32,
     metadata: PieceMetadata,
 }
 
@@ -86,15 +91,16 @@ impl PieceContent {
         created_at: NaiveDateTime,
     ) -> Self {
         Self {
-            metadata_length: (METADATA_LENGTH_SIZE
-                + NUMBER_SIZE
+            metadata_length: (NUMBER_SIZE
                 + OFFSET_SIZE
                 + LENGTH_SIZE
-                + DIGEST_SIZE
+                + DIGEST_LENGTH_SIZE
+                + digest.len()
+                + PARENT_ID_LENGTH_SIZE
+                + parent_id.len()
                 + TRAFFIC_TYPE_SIZE
                 + COST_SIZE
-                + CREATED_AT_SIZE
-                + parent_id.len()) as u64,
+                + CREATED_AT_SIZE) as u32,
             metadata: PieceMetadata {
                 number,
                 offset,
@@ -114,7 +120,7 @@ impl PieceContent {
     }
 
     /// metadata_len returns the length of the metadata section.
-    pub fn metadata_len(&self) -> u64 {
+    pub fn metadata_len(&self) -> u32 {
         self.metadata_length
     }
 
@@ -124,17 +130,91 @@ impl PieceContent {
     }
 }
 
+/// Implement TryFrom<Bytes> for PieceContent for conversion from a byte slice.
+impl TryFrom<Bytes> for PieceContent {
+    type Error = Error;
+
+    /// try_from decodes the piece content request from the byte slice.
+    fn try_from(bytes: Bytes) -> Result<Self> {
+        let metadata_length = u32::from_be_bytes(
+            bytes
+                .get(..METADATA_LENGTH_SIZE)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for metadata length".to_string(),
+                ))?
+                .try_into()?,
+        );
+
+        if bytes.len() != METADATA_LENGTH_SIZE + metadata_length as usize {
+            return Err(Error::InvalidPacket(format!(
+                "expected {} bytes for PieceContent, got {}",
+                METADATA_LENGTH_SIZE + metadata_length as usize,
+                bytes.len()
+            )));
+        }
+
+        let metadata = (
+            bytes.slice(METADATA_LENGTH_SIZE..METADATA_LENGTH_SIZE + metadata_length as usize),
+            metadata_length,
+        )
+            .try_into()?;
+        Ok(PieceContent {
+            metadata_length,
+            metadata,
+        })
+    }
+}
+
+/// Implement From<PieceContent> for Bytes for conversion to a byte slice.
+impl From<PieceContent> for Bytes {
+    /// from converts the piece content request to a byte slice.
+    fn from(content: PieceContent) -> Bytes {
+        let (metadata_bytes, metadata_length) = content.metadata.into();
+        let mut bytes = BytesMut::with_capacity(METADATA_LENGTH_SIZE + metadata_length as usize);
+        bytes.put_u32(metadata_length);
+        bytes.extend_from_slice(&metadata_bytes);
+        bytes.freeze()
+    }
+}
+
 /// PieceMetadata holds the metadata information for a piece.
 #[derive(Debug, Clone)]
 pub struct PieceMetadata {
-    number: u32,
-    offset: u64,
-    length: u64,
-    digest: String,
-    parent_id: String,
-    traffic_type: u8,
-    cost: Duration,
-    created_at: NaiveDateTime,
+    pub number: u32,
+    pub offset: u64,
+    pub length: u64,
+    pub digest: String,
+    pub parent_id: String,
+    pub traffic_type: u8,
+    pub cost: Duration,
+    pub created_at: NaiveDateTime,
+}
+
+/// PieceMetadata implements the PieceMetadata functions.
+impl PieceMetadata {
+    /// new creates a new PieceMetadata.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        number: u32,
+        offset: u64,
+        length: u64,
+        digest: String,
+        parent_id: String,
+        traffic_type: u8,
+        cost: Duration,
+        created_at: NaiveDateTime,
+    ) -> Self {
+        Self {
+            number,
+            offset,
+            length,
+            digest,
+            parent_id,
+            traffic_type,
+            cost,
+            created_at,
+        }
+    }
 }
 
 /// Implement TryFrom<Bytes> for PieceMetadata for conversion from a byte slice.
@@ -153,38 +233,108 @@ impl TryFrom<(Bytes, u32)> for PieceMetadata {
         }
 
         let mut bytes_offset = 0;
-        let number =
-            u32::from_be_bytes(bytes[bytes_offset..bytes_offset + NUMBER_SIZE].try_into()?);
+        let number = u32::from_be_bytes(
+            bytes
+                .get(bytes_offset..bytes_offset + NUMBER_SIZE)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for piece number".to_string(),
+                ))?
+                .try_into()?,
+        );
         bytes_offset += NUMBER_SIZE;
 
-        let offset =
-            u64::from_be_bytes(bytes[bytes_offset..bytes_offset + OFFSET_SIZE].try_into()?);
+        let offset = u64::from_be_bytes(
+            bytes
+                .get(bytes_offset..bytes_offset + OFFSET_SIZE)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for piece offset".to_string(),
+                ))?
+                .try_into()?,
+        );
         bytes_offset += OFFSET_SIZE;
 
-        let length =
-            u64::from_be_bytes(bytes[bytes_offset..bytes_offset + LENGTH_SIZE].try_into()?);
+        let length = u64::from_be_bytes(
+            bytes
+                .get(bytes_offset..bytes_offset + LENGTH_SIZE)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for piece length".to_string(),
+                ))?
+                .try_into()?,
+        );
+
         bytes_offset += LENGTH_SIZE;
 
-        let digest = String::from_utf8(bytes[bytes_offset..bytes_offset + DIGEST_SIZE].to_vec())?;
-        bytes_offset += DIGEST_SIZE;
+        let digest_length = u32::from_be_bytes(
+            bytes
+                .get(bytes_offset..bytes_offset + DIGEST_LENGTH_SIZE)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for digest length".to_string(),
+                ))?
+                .try_into()?,
+        ) as usize;
+        bytes_offset += DIGEST_LENGTH_SIZE;
 
-        let traffic_type = bytes[bytes_offset];
+        let digest = String::from_utf8(
+            bytes
+                .get(bytes_offset..bytes_offset + digest_length)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for digest length".to_string(),
+                ))?
+                .to_vec(),
+        )?;
+        bytes_offset += digest_length;
+
+        let parent_id_length = u32::from_be_bytes(
+            bytes
+                .get(bytes_offset..bytes_offset + PARENT_ID_LENGTH_SIZE)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for parent id length".to_string(),
+                ))?
+                .try_into()?,
+        ) as usize;
+        bytes_offset += PARENT_ID_LENGTH_SIZE;
+
+        let parent_id = String::from_utf8(
+            bytes
+                .get(bytes_offset..bytes_offset + parent_id_length)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for parent id".to_string(),
+                ))?
+                .to_vec(),
+        )?;
+        bytes_offset += parent_id_length;
+
+        let traffic_type = bytes
+            .get(bytes_offset)
+            .ok_or(Error::InvalidPacket(
+                "insufficient bytes for traffic type".to_string(),
+            ))?
+            .to_owned();
         bytes_offset += TRAFFIC_TYPE_SIZE;
 
         let cost = Duration::from_secs(u64::from_be_bytes(
-            bytes[bytes_offset..bytes_offset + COST_SIZE].try_into()?,
+            bytes
+                .get(bytes_offset..bytes_offset + COST_SIZE)
+                .ok_or(Error::InvalidPacket(
+                    "insufficient bytes for cost".to_string(),
+                ))?
+                .try_into()?,
         ));
         bytes_offset += COST_SIZE;
 
         let created_at = DateTime::from_timestamp(
-            i64::from_be_bytes(bytes[bytes_offset..bytes_offset + CREATED_AT_SIZE].try_into()?),
+            i64::from_be_bytes(
+                bytes
+                    .get(bytes_offset..bytes_offset + CREATED_AT_SIZE)
+                    .ok_or(Error::InvalidPacket(
+                        "insufficient bytes for created_at".to_string(),
+                    ))?
+                    .try_into()?,
+            ),
             0,
         )
         .ok_or_else(|| Error::InvalidPacket("invalid timestamp for created_at".to_string()))?
         .naive_utc();
-        bytes_offset += CREATED_AT_SIZE;
-
-        let parent_id = String::from_utf8(bytes[bytes_offset..].to_vec())?;
         Ok(PieceMetadata {
             number,
             offset,
@@ -217,21 +367,25 @@ impl From<PieceMetadata> for (Bytes, u32) {
         let bytes_length = NUMBER_SIZE
             + OFFSET_SIZE
             + LENGTH_SIZE
-            + DIGEST_SIZE
+            + DIGEST_LENGTH_SIZE
+            + digest.len()
+            + PARENT_ID_LENGTH_SIZE
+            + parent_id.len()
             + TRAFFIC_TYPE_SIZE
             + COST_SIZE
-            + CREATED_AT_SIZE
-            + parent_id.len();
+            + CREATED_AT_SIZE;
 
         let mut bytes = BytesMut::with_capacity(bytes_length);
         bytes.put_u32(number);
         bytes.put_u64(offset);
         bytes.put_u64(length);
+        bytes.put_u32(digest.len() as u32);
         bytes.extend_from_slice(digest.as_bytes());
+        bytes.put_u32(parent_id.len() as u32);
+        bytes.extend_from_slice(parent_id);
         bytes.put_u8(traffic_type);
         bytes.put_u64(cost.as_secs());
         bytes.put_i64(created_at.and_utc().timestamp());
-        bytes.extend_from_slice(parent_id);
         (bytes.freeze(), bytes_length as u32)
     }
 }
@@ -241,6 +395,19 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use std::time::Duration;
+
+    fn create_test_piece_content() -> PieceContent {
+        PieceContent::new(
+            42,
+            1024,
+            2048,
+            "a".repeat(32),
+            "test_parent_id".to_string(),
+            1,
+            Duration::from_secs(5),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        )
+    }
 
     fn create_test_metadata() -> PieceMetadata {
         PieceMetadata {
@@ -253,6 +420,223 @@ mod tests {
             cost: Duration::from_secs(5),
             created_at: DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
         }
+    }
+
+    #[test]
+    fn test_piece_content_conversion_roundtrip() {
+        let original = create_test_piece_content();
+        let bytes = Bytes::from(original.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+
+        assert_eq!(result.metadata().number, original.metadata().number);
+        assert_eq!(result.metadata().offset, original.metadata().offset);
+        assert_eq!(result.metadata().length, original.metadata().length);
+        assert_eq!(result.metadata().digest, original.metadata().digest);
+        assert_eq!(result.metadata().parent_id, original.metadata().parent_id);
+        assert_eq!(
+            result.metadata().traffic_type,
+            original.metadata().traffic_type
+        );
+        assert_eq!(result.metadata().cost, original.metadata().cost);
+        assert_eq!(result.metadata().created_at, original.metadata().created_at);
+        assert_eq!(result.metadata_len(), original.metadata_len());
+    }
+
+    #[test]
+    fn test_piece_content_try_from_insufficient_bytes_for_metadata_length() {
+        let short_bytes = Bytes::from(vec![0u8; 4]); // Less than METADATA_LENGTH_SIZE (8)
+        let result = PieceContent::try_from(short_bytes);
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::InvalidPacket(_)));
+    }
+
+    #[test]
+    fn test_piece_content_try_from_insufficient_metadata_bytes() {
+        let mut bytes = BytesMut::new();
+        bytes.put_u32(100); // metadata_length = 100
+        bytes.put(&vec![0u8; 50][..]); // But only provide 50 bytes of metadata
+
+        let result = PieceContent::try_from(bytes.freeze());
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::InvalidPacket(_)));
+    }
+
+    #[test]
+    fn test_piece_content_with_empty_parent_id() {
+        let piece_content = PieceContent::new(
+            1,
+            0,
+            100,
+            "b".repeat(32),
+            String::new(), // Empty parent_id
+            2,
+            Duration::from_secs(1),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let bytes = Bytes::from(piece_content.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+
+        assert_eq!(result.metadata().parent_id, "");
+        assert_eq!(result.metadata().number, 1);
+        assert_eq!(result.metadata().traffic_type, 2);
+        assert_eq!(result.metadata().length, 100);
+    }
+
+    #[test]
+    fn test_piece_content_with_long_parent_id() {
+        let long_parent_id = "x".repeat(1000);
+        let piece_content = PieceContent::new(
+            999,
+            12345,
+            67890,
+            "c".repeat(32),
+            long_parent_id.clone(),
+            255,
+            Duration::from_secs(3600),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let bytes = Bytes::from(piece_content.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+
+        assert_eq!(result.metadata().parent_id, long_parent_id);
+        assert_eq!(result.metadata().number, 999);
+        assert_eq!(result.metadata().traffic_type, 255);
+        assert_eq!(result.metadata().length, 67890);
+    }
+
+    #[test]
+    fn test_piece_content_with_zero_values() {
+        let piece_content = PieceContent::new(
+            0,
+            0,
+            0,
+            "d".repeat(32),
+            "zero_test".to_string(),
+            0,
+            Duration::from_secs(0),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let bytes = Bytes::from(piece_content.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+
+        assert_eq!(result.metadata().number, 0);
+        assert_eq!(result.metadata().offset, 0);
+        assert_eq!(result.metadata().length, 0);
+        assert_eq!(result.metadata().traffic_type, 0);
+        assert_eq!(result.metadata().cost, Duration::from_secs(0));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_piece_content_with_max_values() {
+        let piece_content = PieceContent::new(
+            u32::MAX,
+            u64::MAX,
+            u64::MAX,
+            "e".repeat(32),
+            "max_values_test".to_string(),
+            u8::MAX,
+            Duration::from_secs(u64::MAX),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let bytes = Bytes::from(piece_content.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+
+        assert_eq!(result.metadata().number, u32::MAX);
+        assert_eq!(result.metadata().offset, u64::MAX);
+        assert_eq!(result.metadata().length, u64::MAX);
+        assert_eq!(result.metadata().traffic_type, u8::MAX);
+        assert_eq!(result.metadata().cost, Duration::from_secs(u64::MAX));
+    }
+
+    #[test]
+    fn test_piece_content_metadata_length_calculation() {
+        let piece_content = PieceContent::new(
+            123,
+            456,
+            789,
+            "f".repeat(32),
+            "length_test".to_string(),
+            42,
+            Duration::from_secs(100),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let expected_length = (NUMBER_SIZE
+            + OFFSET_SIZE
+            + LENGTH_SIZE
+            + DIGEST_LENGTH_SIZE
+            + 32 // digest length
+            + PARENT_ID_LENGTH_SIZE
+            + "length_test".len()
+            + TRAFFIC_TYPE_SIZE
+            + COST_SIZE
+            + CREATED_AT_SIZE) as u32;
+
+        assert_eq!(piece_content.metadata_len(), expected_length);
+
+        let bytes = Bytes::from(piece_content.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+        assert_eq!(result.metadata_len(), expected_length);
+    }
+
+    #[test]
+    fn test_piece_content_with_short_digest() {
+        let piece_content = PieceContent::new(
+            1,
+            0,
+            100,
+            "short".to_string(), // Shorter than typical 32-char digest
+            "test".to_string(),
+            1,
+            Duration::from_secs(1),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let bytes = Bytes::from(piece_content.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+
+        assert_eq!(result.metadata().digest, "short");
+        assert_eq!(result.metadata().number, 1);
+    }
+
+    #[test]
+    fn test_piece_content_with_long_digest() {
+        let long_digest = "g".repeat(128); // Longer than typical digest
+        let piece_content = PieceContent::new(
+            5,
+            1000,
+            2000,
+            long_digest.clone(),
+            "digest_test".to_string(),
+            10,
+            Duration::from_secs(50),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let bytes = Bytes::from(piece_content.clone());
+        let result = PieceContent::try_from(bytes).unwrap();
+
+        assert_eq!(result.metadata().digest, long_digest);
+        assert_eq!(result.metadata().number, 5);
+        assert_eq!(result.metadata().offset, 1000);
+        assert_eq!(result.metadata().length, 2000);
+    }
+
+    #[test]
+    fn test_piece_content_bytes_structure() {
+        let piece_content = create_test_piece_content();
+        let bytes: Bytes = piece_content.clone().into();
+
+        let metadata_length_bytes = &bytes[..METADATA_LENGTH_SIZE];
+        let metadata_length = u32::from_be_bytes(metadata_length_bytes.try_into().unwrap());
+        assert_eq!(metadata_length, piece_content.metadata_len());
+        assert_eq!(bytes.len(), METADATA_LENGTH_SIZE + metadata_length as usize);
     }
 
     #[test]
@@ -277,15 +661,16 @@ mod tests {
         assert_eq!(piece_content.metadata().cost, Duration::from_secs(5));
         assert_eq!(
             piece_content.metadata_len(),
-            (METADATA_LENGTH_SIZE
-                + NUMBER_SIZE
+            (NUMBER_SIZE
                 + OFFSET_SIZE
                 + LENGTH_SIZE
-                + DIGEST_SIZE
+                + DIGEST_LENGTH_SIZE
+                + piece_content.metadata().digest.len()
+                + PARENT_ID_LENGTH_SIZE
+                + piece_content.metadata().parent_id.len()
                 + TRAFFIC_TYPE_SIZE
                 + COST_SIZE
-                + CREATED_AT_SIZE
-                + "test_parent_id".len()) as u64
+                + CREATED_AT_SIZE) as u32,
         );
     }
 

--- a/src/tlv/piece_content.rs
+++ b/src/tlv/piece_content.rs
@@ -15,101 +15,443 @@
  */
 
 use crate::error::{Error, Result};
-use crate::MAX_VALUE_SIZE;
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
+use chrono::{DateTime, NaiveDateTime};
 use std::convert::TryFrom;
+use std::time::Duration;
 
-/// PieceContent represents the content of a piece.
+/// METADATA_LENGTH_SIZE is the size of the metadata length in bytes.
+pub const METADATA_LENGTH_SIZE: usize = 8;
+
+/// NUMBER_SIZE is the size of the piece number in bytes.
+const NUMBER_SIZE: usize = 4;
+
+/// OFFSET_SIZE is the size of the offest in bytes.
+const OFFSET_SIZE: usize = 8;
+
+/// LENGTH_SIZE is the size of the length in bytes.
+const LENGTH_SIZE: usize = 8;
+
+/// DIGEST_SIZE is the size of the digest in bytes.
+const DIGEST_SIZE: usize = 32;
+
+/// TRAFFIC_TYPE_SIZE is the size of the traffic type in bytes.
+const TRAFFIC_TYPE_SIZE: usize = 1;
+
+/// COST_SIZE is the size of the cost in bytes.
+const COST_SIZE: usize = 64;
+
+/// CREATED_AT_SIZE is the size of the created at in bytes.
+const CREATED_AT_SIZE: usize = 64;
+
+/// PieceContent represents a piece metadata and piece content request.
+///
+/// Value Format:
+///   - Metadata Length (8 bytes): Length of the metadata section.
+///   - Number (4 bytes): Piece number to download.
+///   - Offset (8 bytes): Byte offset in the file.
+///   - Length (8 bytes): Length of the piece in bytes.
+///   - Digest (32 bytes): CRC32 hash of the piece content.
+///   - Parent ID (variable): Parent task identifier.
+///   - Traffic Type (1 byte): Network traffic classification type.
+///   - Cost (64 bytes): Download cost in seconds.
+///   - Created At (8 bytes): Creation timestamp as Unix epoch seconds.
+///   - Content (variable): Piece content bytes.
+///
+/// ```text
+/// --------------------------------------------------------------------------------------------------------------------------------------------------------
+/// | Metadata Length (8 bytes) | Number (4 bytes) |  Offset (8 bytes) |  Length (8 bytes) |  Digest (32 bytes) | Traffic Type (1 byte) |  Cost (64 bytes) |
+/// --------------------------------------------------------------------------------------------------------------------------------------------------------
+/// | Created At (64 bytes) | Parent ID (variable) | Content (variable) |
+/// ---------------------------------------------------------------------
+/// ```
 #[derive(Debug, Clone)]
-pub struct PieceContent(Bytes);
+pub struct PieceContent {
+    metadata_length: u64,
+    metadata: PieceMetadata,
+}
 
 /// PieceContent implements the PieceContent functions.
 impl PieceContent {
-    /// new creates a new piece content.
-    pub fn new(content: Bytes) -> Result<Self> {
-        // Check content length
-        if content.len() > MAX_VALUE_SIZE {
+    /// new creates a new PieceContent request.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        number: u32,
+        offset: u64,
+        length: u64,
+        digest: String,
+        parent_id: String,
+        traffic_type: u8,
+        cost: Duration,
+        created_at: NaiveDateTime,
+    ) -> Self {
+        Self {
+            metadata_length: (METADATA_LENGTH_SIZE
+                + NUMBER_SIZE
+                + OFFSET_SIZE
+                + LENGTH_SIZE
+                + DIGEST_SIZE
+                + TRAFFIC_TYPE_SIZE
+                + COST_SIZE
+                + CREATED_AT_SIZE
+                + parent_id.len()) as u64,
+            metadata: PieceMetadata {
+                number,
+                offset,
+                length,
+                digest,
+                parent_id,
+                traffic_type,
+                cost,
+                created_at,
+            },
+        }
+    }
+
+    ///  metadata returns the piece metadata.
+    pub fn metadata(&self) -> PieceMetadata {
+        self.metadata.clone()
+    }
+
+    /// metadata_len returns the length of the metadata section.
+    pub fn metadata_len(&self) -> u64 {
+        self.metadata_length
+    }
+
+    /// is_empty returns whether the piece content request is empty.
+    pub fn is_empty(&self) -> bool {
+        self.metadata.length == 0
+    }
+}
+
+/// PieceMetadata holds the metadata information for a piece.
+#[derive(Debug, Clone)]
+pub struct PieceMetadata {
+    number: u32,
+    offset: u64,
+    length: u64,
+    digest: String,
+    parent_id: String,
+    traffic_type: u8,
+    cost: Duration,
+    created_at: NaiveDateTime,
+}
+
+/// Implement TryFrom<Bytes> for PieceMetadata for conversion from a byte slice.
+impl TryFrom<(Bytes, u32)> for PieceMetadata {
+    type Error = Error;
+
+    /// try_from decodes the piece metadata request from the byte slice.
+    fn try_from(input: (Bytes, u32)) -> Result<Self> {
+        let (bytes, length) = input;
+        if bytes.len() != length as usize {
             return Err(Error::InvalidLength(format!(
-                "content length {} exceeds maximum size {}",
-                content.len(),
-                MAX_VALUE_SIZE
+                "expected {} bytes for PieceMetadata, got {}",
+                length,
+                bytes.len()
             )));
         }
 
-        Ok(PieceContent(content))
-    }
+        let mut bytes_offset = 0;
+        let number =
+            u32::from_be_bytes(bytes[bytes_offset..bytes_offset + NUMBER_SIZE].try_into()?);
+        bytes_offset += NUMBER_SIZE;
 
-    /// len returns the length of the piece content.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
+        let offset =
+            u64::from_be_bytes(bytes[bytes_offset..bytes_offset + OFFSET_SIZE].try_into()?);
+        bytes_offset += OFFSET_SIZE;
 
-    /// is_empty returns whether the piece content is empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        let length =
+            u64::from_be_bytes(bytes[bytes_offset..bytes_offset + LENGTH_SIZE].try_into()?);
+        bytes_offset += LENGTH_SIZE;
+
+        let digest = String::from_utf8(bytes[bytes_offset..bytes_offset + DIGEST_SIZE].to_vec())?;
+        bytes_offset += DIGEST_SIZE;
+
+        let traffic_type = bytes[bytes_offset];
+        bytes_offset += TRAFFIC_TYPE_SIZE;
+
+        let cost = Duration::from_secs(u64::from_be_bytes(
+            bytes[bytes_offset..bytes_offset + COST_SIZE].try_into()?,
+        ));
+        bytes_offset += COST_SIZE;
+
+        let created_at = DateTime::from_timestamp(
+            i64::from_be_bytes(bytes[bytes_offset..bytes_offset + CREATED_AT_SIZE].try_into()?),
+            0,
+        )
+        .ok_or_else(|| Error::InvalidPacket("invalid timestamp for created_at".to_string()))?
+        .naive_utc();
+        bytes_offset += CREATED_AT_SIZE;
+
+        let parent_id = String::from_utf8(bytes[bytes_offset..].to_vec())?;
+        Ok(PieceMetadata {
+            number,
+            offset,
+            length,
+            digest,
+            parent_id,
+            traffic_type,
+            cost,
+            created_at,
+        })
     }
 }
 
-/// Implement TryFrom<Bytes> for PieceContent.
-impl TryFrom<Bytes> for PieceContent {
-    type Error = Error;
+/// Implement From<PieceMetadata> for Bytes for conversion to a byte slice.
+impl From<PieceMetadata> for (Bytes, u32) {
+    /// from converts the piece metadata request to a byte slice.
+    fn from(metadata: PieceMetadata) -> (Bytes, u32) {
+        let PieceMetadata {
+            number,
+            offset,
+            length,
+            digest,
+            parent_id,
+            traffic_type,
+            cost,
+            created_at,
+        } = metadata;
 
-    /// try_from converts Bytes to PieceContent.
-    fn try_from(bytes: Bytes) -> Result<Self> {
-        Self::new(bytes)
-    }
-}
+        let parent_id = parent_id.as_bytes();
+        let bytes_length = NUMBER_SIZE
+            + OFFSET_SIZE
+            + LENGTH_SIZE
+            + DIGEST_SIZE
+            + TRAFFIC_TYPE_SIZE
+            + COST_SIZE
+            + CREATED_AT_SIZE
+            + parent_id.len();
 
-/// Implement From<PieceContent> for Bytes.
-impl From<PieceContent> for Bytes {
-    /// from converts PieceContent to Bytes.
-    fn from(piece: PieceContent) -> Self {
-        piece.0
+        let mut bytes = BytesMut::with_capacity(bytes_length);
+        bytes.put_u32(number);
+        bytes.put_u64(offset);
+        bytes.put_u64(length);
+        bytes.extend_from_slice(digest.as_bytes());
+        bytes.put_u8(traffic_type);
+        bytes.put_u64(cost.as_secs());
+        bytes.put_i64(created_at.and_utc().timestamp());
+        bytes.extend_from_slice(parent_id);
+        (bytes.freeze(), bytes_length as u32)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
+    use std::time::Duration;
 
-    #[test]
-    fn test_new() {
-        let content = vec![1, 2, 3, 4];
-        let result = PieceContent::new(content.into());
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 4);
-    }
-
-    #[test]
-    fn test_is_empty() {
-        let content = Bytes::new();
-        let result = PieceContent::new(content);
-
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
-    }
-
-    #[test]
-    fn test_valid_conversion() {
-        let content = vec![1, 2, 3, 4];
-        let bytes = Bytes::from(content.clone());
-
-        let piece_content = PieceContent::try_from(bytes.clone()).unwrap();
-        let bytes_back: Bytes = piece_content.clone().into();
-        assert_eq!(bytes_back, content);
-    }
-
-    #[test]
-    fn test_invalid_conversion() {
-        let large_content = vec![0; MAX_VALUE_SIZE + 1];
-        let bytes = Bytes::from(large_content);
-
-        let result = PieceContent::try_from(bytes);
-        assert!(result.is_err());
-        match result {
-            Err(Error::InvalidLength(_)) => (),
-            _ => panic!("Expected InvalidLength error"),
+    fn create_test_metadata() -> PieceMetadata {
+        PieceMetadata {
+            number: 42,
+            offset: 1024,
+            length: 2048,
+            digest: "a".repeat(32),
+            parent_id: "test_parent_id".to_string(),
+            traffic_type: 1,
+            cost: Duration::from_secs(5),
+            created_at: DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
         }
+    }
+
+    #[test]
+    fn test_piece_content_new() {
+        let piece_content = PieceContent::new(
+            42,
+            1024,
+            2048,
+            "a".repeat(32),
+            "test_parent_id".to_string(),
+            1,
+            Duration::from_secs(5),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        assert_eq!(piece_content.metadata().number, 42);
+        assert_eq!(piece_content.metadata().offset, 1024);
+        assert_eq!(piece_content.metadata().length, 2048);
+        assert_eq!(piece_content.metadata().digest, "a".repeat(32));
+        assert_eq!(piece_content.metadata().parent_id, "test_parent_id");
+        assert_eq!(piece_content.metadata().traffic_type, 1);
+        assert_eq!(piece_content.metadata().cost, Duration::from_secs(5));
+        assert_eq!(
+            piece_content.metadata_len(),
+            (METADATA_LENGTH_SIZE
+                + NUMBER_SIZE
+                + OFFSET_SIZE
+                + LENGTH_SIZE
+                + DIGEST_SIZE
+                + TRAFFIC_TYPE_SIZE
+                + COST_SIZE
+                + CREATED_AT_SIZE
+                + "test_parent_id".len()) as u64
+        );
+    }
+
+    #[test]
+    fn test_piece_content_is_empty() {
+        let empty_piece = PieceContent::new(
+            0,
+            0,
+            0,
+            "a".repeat(32),
+            "test".to_string(),
+            0,
+            Duration::from_secs(0),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        let non_empty_piece = PieceContent::new(
+            1,
+            0,
+            100,
+            "a".repeat(32),
+            "test".to_string(),
+            0,
+            Duration::from_secs(0),
+            DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        );
+
+        assert!(empty_piece.is_empty());
+        assert!(!non_empty_piece.is_empty());
+    }
+
+    #[test]
+    fn test_piece_metadata_conversion_roundtrip() {
+        let metadata = create_test_metadata();
+        let (bytes, length) = <(Bytes, u32)>::from(metadata.clone());
+        let result = PieceMetadata::try_from((bytes, length)).unwrap();
+
+        assert_eq!(result.number, metadata.number);
+        assert_eq!(result.offset, metadata.offset);
+        assert_eq!(result.length, metadata.length);
+        assert_eq!(result.digest, metadata.digest);
+        assert_eq!(result.parent_id, metadata.parent_id);
+        assert_eq!(result.traffic_type, metadata.traffic_type);
+        assert_eq!(result.cost, metadata.cost);
+        assert_eq!(result.created_at, metadata.created_at);
+    }
+
+    #[test]
+    fn test_piece_metadata_try_from_invalid_length() {
+        let metadata = create_test_metadata();
+        let (bytes, correct_length) = <(Bytes, u32)>::from(metadata);
+        let wrong_length = correct_length + 10;
+        let result = PieceMetadata::try_from((bytes, wrong_length));
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::InvalidLength(_)));
+    }
+
+    #[test]
+    fn test_piece_metadata_try_from_too_short_bytes() {
+        let short_bytes = Bytes::from(vec![0u8; 10]);
+        let result = PieceMetadata::try_from((short_bytes, 10));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_piece_metadata_with_empty_parent_id() {
+        let metadata = PieceMetadata {
+            number: 1,
+            offset: 0,
+            length: 100,
+            digest: "b".repeat(32),
+            parent_id: String::new(),
+            traffic_type: 2,
+            cost: Duration::from_secs(1),
+            created_at: DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        };
+
+        let (bytes, length) = <(Bytes, u32)>::from(metadata.clone());
+        let result = PieceMetadata::try_from((bytes, length)).unwrap();
+
+        assert_eq!(result.parent_id, "");
+        assert_eq!(result.number, 1);
+        assert_eq!(result.traffic_type, 2);
+    }
+
+    #[test]
+    fn test_piece_metadata_with_long_parent_id() {
+        let long_parent_id = "x".repeat(1000); // Very long parent_id
+        let metadata = PieceMetadata {
+            number: 999,
+            offset: 12345,
+            length: 67890,
+            digest: "c".repeat(32),
+            parent_id: long_parent_id.clone(),
+            traffic_type: 255,
+            cost: Duration::from_secs(3600),
+            created_at: DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        };
+
+        let (bytes, length) = <(Bytes, u32)>::from(metadata.clone());
+        let result = PieceMetadata::try_from((bytes, length)).unwrap();
+
+        assert_eq!(result.parent_id, long_parent_id);
+        assert_eq!(result.number, 999);
+        assert_eq!(result.traffic_type, 255);
+    }
+
+    #[test]
+    fn test_piece_metadata_with_zero_cost() {
+        let metadata = PieceMetadata {
+            number: 0,
+            offset: 0,
+            length: 0,
+            digest: "d".repeat(32),
+            parent_id: "zero_cost_test".to_string(),
+            traffic_type: 0,
+            cost: Duration::from_secs(0),
+            created_at: DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        };
+
+        let (bytes, length) = <(Bytes, u32)>::from(metadata.clone());
+        let result = PieceMetadata::try_from((bytes, length)).unwrap();
+
+        assert_eq!(result.cost, Duration::from_secs(0));
+        assert_eq!(result.parent_id, "zero_cost_test");
+    }
+
+    #[test]
+    fn test_piece_metadata_with_max_values() {
+        let metadata = PieceMetadata {
+            number: u32::MAX,
+            offset: u64::MAX,
+            length: u64::MAX,
+            digest: "e".repeat(32),
+            parent_id: "max_values_test".to_string(),
+            traffic_type: u8::MAX,
+            cost: Duration::from_secs(u64::MAX),
+            created_at: DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        };
+
+        let (bytes, length) = <(Bytes, u32)>::from(metadata.clone());
+        let result = PieceMetadata::try_from((bytes, length)).unwrap();
+
+        assert_eq!(result.number, u32::MAX);
+        assert_eq!(result.offset, u64::MAX);
+        assert_eq!(result.length, u64::MAX);
+        assert_eq!(result.traffic_type, u8::MAX);
+        assert_eq!(result.cost, Duration::from_secs(u64::MAX));
+    }
+
+    #[test]
+    fn test_piece_metadata_invalid_utf8_in_digest() {
+        let metadata_with_short_digest = PieceMetadata {
+            number: 1,
+            offset: 0,
+            length: 100,
+            digest: "short".to_string(),
+            parent_id: "test".to_string(),
+            traffic_type: 1,
+            cost: Duration::from_secs(1),
+            created_at: DateTime::from_timestamp(1693152000, 0).unwrap().naive_utc(),
+        };
+
+        let (bytes, length) = <(Bytes, u32)>::from(metadata_with_short_digest);
+        let result = PieceMetadata::try_from((bytes, length));
+        assert!(result.is_ok());
     }
 }

--- a/tests/prop_tests.rs
+++ b/tests/prop_tests.rs
@@ -1,6 +1,23 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use bytes::Bytes;
 use proptest::prelude::*;
 use proptest::test_runner::TestRunner;
+use vortex_protocol::tlv::download_piece::DownloadPiece;
 use vortex_protocol::tlv::Tag;
 use vortex_protocol::Vortex;
 
@@ -8,14 +25,11 @@ use vortex_protocol::Vortex;
 fn generate_value_bytes(tag: Tag) -> Bytes {
     match tag {
         Tag::DownloadPiece => {
-            // Task ID must be 32 bytes (64 hex chars).
             let task_id = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
             let piece_id = 42;
-            format!("{}-{}", task_id, piece_id).into_bytes().into()
-        }
-        Tag::PieceContent => {
-            // PieceContent can be any bytes.
-            vec![1, 2, 3, 4].into()
+            let download_piece = DownloadPiece::new(task_id.to_string(), piece_id);
+
+            download_piece.into()
         }
         Tag::Close => {
             // Close tag can be empty.
@@ -23,10 +37,14 @@ fn generate_value_bytes(tag: Tag) -> Bytes {
         }
         Tag::Error => {
             // Error format is "code:message".
-            format!("{}:test error", 1u8).into_bytes().into()
+            format!("{}test error", 1u8).into_bytes().into()
         }
         Tag::Reserved(_) => {
             // Reserved tags can have any format.
+            vec![].into()
+        }
+        _ => {
+            // For other tags, return empty bytes.
             vec![].into()
         }
     }
@@ -34,12 +52,7 @@ fn generate_value_bytes(tag: Tag) -> Bytes {
 
 /// Generate arbitrary valid packets.
 fn arb_packet() -> impl Strategy<Value = Vortex> {
-    let arb_tag = prop_oneof![
-        Just(Tag::DownloadPiece),
-        Just(Tag::PieceContent),
-        Just(Tag::Close),
-        Just(Tag::Error)
-    ];
+    let arb_tag = prop_oneof![Just(Tag::DownloadPiece), Just(Tag::Close), Just(Tag::Error)];
 
     arb_tag.prop_map(|tag| {
         let value = generate_value_bytes(tag);
@@ -67,14 +80,14 @@ where
 fn test_roundtrip_serialization() {
     run_test(|packet| {
         let id = packet.id();
-        let tag = *packet.tag();
+        let tag = packet.tag();
         let length = packet.length();
 
         let serialized: Bytes = packet.into();
         let deserialized: Vortex = serialized.try_into().expect("Failed to deserialize packet");
 
         prop_assert_eq!(id, deserialized.id());
-        prop_assert_eq!(tag, *deserialized.tag());
+        prop_assert_eq!(tag, deserialized.tag());
         prop_assert_eq!(length, deserialized.length());
         Ok(())
     });
@@ -94,7 +107,7 @@ fn test_packet_length() {
 #[test]
 fn test_packet_value_constraints() {
     run_test(|packet| {
-        let tag = *packet.tag();
+        let tag = packet.tag();
 
         let bytes: Bytes = packet.into();
         prop_assert!(bytes.len() >= 6);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the Vortex protocol implementation to improve type safety, correctness, and maintainability. The main changes include updating the packet header structure, simplifying benchmark coverage, and improving error handling for edge cases. Additionally, the documentation is updated to accurately reflect the protocol's binary format.

**Protocol and Type System Improvements**
- Refactored the `Header` struct: now uses explicit types (`u8` for ID and tag, `u32` for length), derives `Serialize` and `Deserialize`, and provides helper constructors for different packet types. The conversion logic between `Header` and `Bytes` is now encapsulated in `TryFrom`/`From` implementations, improving type safety and clarity. (`[[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L32-R143)`, `[[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L45-R164)`)
- Changed the `Vortex` packet construction and parsing logic to use the new `Header` structure, ensuring consistent and correct parsing/serialization. The `tag()` and `length()` methods now return the correct types, and conversion between bytes and packets is more robust. (`[[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L74-R181)`, `[[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L98-R216)`, `[[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L139-R253)`, `[[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L173-R266)`)
- Added a maximum value size check (`MAX_VALUE_SIZE`) to prevent oversized packets from being constructed or parsed. (`[src/lib.rsR284-R303](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R284-R303)`)

**Benchmark and Dependency Updates**
- Benchmarks in `benches/vortex.rs` now focus on realistic packet types (`DownloadPiece`, `PieceContent`) instead of arbitrary byte sizes, providing more meaningful performance data. (`[[1]](diffhunk://#diff-ac50fcf823a840d089ffa404f5d4123374fec8ebbdb8a6c2169becd87f31edd8R18-L60)`, `[[2]](diffhunk://#diff-ac50fcf823a840d089ffa404f5d4123374fec8ebbdb8a6c2169becd87f31edd8L71-R74)`, `[[3]](diffhunk://#diff-ac50fcf823a840d089ffa404f5d4123374fec8ebbdb8a6c2169becd87f31edd8L122-R114)`)
- Added `serde` and `chrono` as dependencies for serialization and timestamp handling. (`[Cargo.tomlR17-R18](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R17-R18)`)
- Updated imports to include `serde` derives. (`[src/lib.rsR20](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R20)`)

**Error Handling**
- Introduced a new `InvalidTag` error variant for better error reporting when an unknown or malformed tag is encountered during parsing. (`[src/error/mod.rsR28-R31](diffhunk://#diff-f43f218cc5fee24623f17725c9bc2c541d64b2e9c1d8ca5345de67ef2a3b7392R28-R31)`)

**Documentation**
- Updated protocol documentation in `docs/README.md` and code comments to clarify field sizes (now consistently described as "1 byte" for ID and tag, "4 bytes" for length) and to match the actual implementation. (`[[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L9-R11)`, `[[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L30-R36)`, `[[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L45-R164)`)
- Cleaned up benchmark documentation in `README.md` to match the new benchmarks. (`[README.mdL35-L41](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-L41)`)

These changes collectively make the protocol more robust, easier to use, and better documented, while also making benchmarks more meaningful and maintainable.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
