### PR TITLE
feat(lib): add getters for Header fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,21 @@ impl Header {
             length: value_length,
         }
     }
+
+    /// id returns the packet identifier.
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+
+    /// tag returns the tag.
+    pub fn tag(&self) -> tlv::Tag {
+        self.tag
+    }
+
+    /// length returns the length of the value field.
+    pub fn length(&self) -> u32 {
+        self.length
+    }
 }
 
 /// Implement TryFrom<Bytes> for Header.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds getter methods to the `Header` struct in `src/lib.rs` to provide easier and more idiomatic access to its fields.

Enhancements to `Header` struct:

* Added `id`, `tag`, and `length` getter methods to the `Header` implementation, allowing users to retrieve these fields directly.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
